### PR TITLE
Record and check process start time

### DIFF
--- a/src/subcommands/start.ts
+++ b/src/subcommands/start.ts
@@ -6,9 +6,6 @@ import { persistPid, getActiveProcesses, createLogStream } from '../utils/ps';
 import { exec, execDetached } from '../utils/processes';
 import { printError } from '../utils/errors';
 
-// TODO: Include process timestamp in identifier to avoid PID conflicts across reboots
-// TODO: Monitor detached processes to determine if they succesfully started or not
-// TODO: Only start if it's not already running
 export const startService = async (
   serviceName: string,
   run: string,

--- a/src/subcommands/stop.ts
+++ b/src/subcommands/stop.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import fs from 'mz/fs';
-import { execSync } from 'child_process';
 
 import { exec } from '../utils/processes';
 import { processExists, getActiveProcesses } from '../utils/ps';
@@ -11,7 +10,10 @@ export const stopProcess = async (name: string, pid: number) => {
   console.log(chalk`Stopping {bold ${name}} with pid {bold ${pid}}`);
   if (await processExists(pid)) {
     // https://stackoverflow.com/a/8406413
-    execSync(`kill -TERM -${pid}`);
+    await exec(`kill -SIGINT -${pid}`);
+
+    // TODO: Add a `chip stop --force` flag that uses `-TERM` signal:
+    // execSync(`kill -TERM -${pid}`);
   } else {
     console.log(chalk`Unknown process with pid {bold ${pid}}`);
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -77,11 +77,21 @@ export const readServices = async (
     : allServices;
 };
 
+/**
+ * All versions of chip since v1.2.1 should include `startTime` in these
+ * records. However, older versions of chip did not. Hence why `startTime` is
+ * optional.
+ */
+export interface ProcessRecord {
+  pid: number;
+
+  /** When the process was started (as a unix timestamp in milliseconds) */
+  startTime?: number;
+}
+
 export interface Processes {
   [projectName: string]:
-    | {
-        [serviceName: string]: { pid: number } | undefined;
-      }
+    | { [serviceName: string]: ProcessRecord | undefined }
     | undefined;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,14 @@
 import { log } from './log';
 
-export const printError = (error: any) => {
-  log`{red An error occurred}`;
-  console.error(error);
+/**
+ * Prints a succinct error message (without a full stack trace). Useful
+ * for when non-fatal errors occur. Allows you to log them without polluting
+ * stdout/stderr with stack traces that detract from other important output.
+ */
+export const printError = ({ output, message }: any) => {
+  let msg = output || message || '---';
+  if (typeof msg === 'string') msg = msg.trim();
+  log`{red Error:} ${msg}`;
 };
 
 export const handleErrors = <T>(fn: (args: T) => Promise<void>) => async (
@@ -11,7 +17,8 @@ export const handleErrors = <T>(fn: (args: T) => Promise<void>) => async (
   try {
     await fn(args);
   } catch (e) {
-    printError(e);
+    log`{red An error occurred}`;
+    console.error(e);
     process.exit(1);
   }
 };

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -26,6 +26,20 @@ export const processExists = async (pid: number) => {
   }
 };
 
+/**
+ * Returns the process start time as unix timestamp or `undefined` if no
+ * process with the given `pid` exists
+ */
+export const processStartTime = async (pid: number) => {
+  try {
+    // Sample output: `Wed Sep  2 11:17:24 2020`
+    const startDate = await exec(`ps -p ${pid} -o lstart=`);
+    return new Date(startDate).getTime();
+  } catch (e) {
+    return undefined;
+  }
+};
+
 export const persistPid = async (
   projectName: string,
   serviceName: string,

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -6,7 +6,7 @@ import {
   writeJsonFile,
   CHIP_LOGS_DIR,
 } from './files';
-import { readProcesses } from './config';
+import { readProcesses, ProcessRecord } from './config';
 
 export const initChip = async () => {
   if (!(await fs.exists(CHIP_DIR))) await fs.mkdir(CHIP_DIR);
@@ -30,13 +30,16 @@ export const processExists = async (pid: number) => {
  * Returns the process start time as unix timestamp or `undefined` if no
  * process with the given `pid` exists
  */
-export const processStartTime = async (pid: number) => {
+export const lookupStartTime = async (pid: number) => {
   try {
     // Sample output: `Wed Sep  2 11:17:24 2020`
     const startDate = await exec(`ps -p ${pid} -o lstart=`);
     return new Date(startDate).getTime();
   } catch (e) {
-    return undefined;
+    if (e.message) {
+      e.message = `Failed to get start start time for pid ${pid}: ${e.message}`;
+    }
+    throw e;
   }
 };
 
@@ -45,9 +48,10 @@ export const persistPid = async (
   serviceName: string,
   pid: number,
 ) => {
+  const startTime = await lookupStartTime(pid);
   const processes = await readProcesses();
   if (!processes[projectName]) processes[projectName] = {};
-  processes[projectName]![serviceName] = { pid };
+  processes[projectName]![serviceName] = { pid, startTime };
   await writeJsonFile(CHIP_PROCESSES_FILE, processes);
 };
 
@@ -58,10 +62,19 @@ export const getAllProcesses = async (projectName: string) => {
 };
 
 export const getActiveProcesses = async (projectName: string) => {
-  const activeProcesses: { [name: string]: { pid: number } } = {};
+  const activeProcesses: { [name: string]: ProcessRecord } = {};
   const processes = (await getAllProcesses(projectName)) || {};
   for (const [name, config] of Object.entries(processes)) {
-    if (await processExists(config!.pid)) activeProcesses[name] = config!;
+    const { pid, startTime } = config!;
+    if (await processExists(pid)) {
+      if (startTime) {
+        const currentStartTime = await lookupStartTime(pid);
+        if (currentStartTime === startTime) activeProcesses[name] = config!;
+      } else {
+        // Handle missing `startTime` for backwards compatibility
+        activeProcesses[name] = config!;
+      }
+    }
   }
   return activeProcesses;
 };

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -27,7 +27,7 @@ export const processExists = async (pid: number) => {
 };
 
 /**
- * Returns the process start time as unix timestamp or `undefined` if no
+ * Returns the process start time as unix timestamp. Throws an error if no
  * process with the given `pid` exists
  */
 export const lookupStartTime = async (pid: number) => {


### PR DESCRIPTION
This PR causes the start time of each spawned process to be recorded in the `processes.json` file. This allows `chip` to detect when a new process is using the same PID as a process it had formerly spawned. 

One scenario that can cause this to happen is rebooting your machine while chip processes are running. When your machine reboots, those chip processes are all gone. But your machine might use some PIDs that chip has stored in `processes.json` for system startup processes. Chip will then see these processes (e.g. with `chip list`) and think it created them because they have the same PID.

Recording and comparing the start time of processes in addition to their PID resolves this. In the example above, the start time of the new system processes would differ because they would have started after the reboot, but the `chip.yml` would have recorded start times from before the reboot.