### PR TITLE
Moar docker integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "buildw": "tsc --watch"
   },
   "dependencies": {
+    "@types/humanize-duration": "^3.18.1",
     "@types/mz": "^2.7.0",
     "chalk": "^3.0.0",
+    "humanize-duration": "^3.23.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.19",
     "mz": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -31,24 +31,25 @@
     "buildw": "tsc --watch"
   },
   "dependencies": {
-    "@types/humanize-duration": "^3.18.1",
-    "@types/mz": "^2.7.0",
-    "chalk": "^3.0.0",
+    "chalk": "^4.1.0",
     "humanize-duration": "^3.23.1",
-    "js-yaml": "^3.13.1",
-    "lodash": "^4.17.19",
+    "js-yaml": "^3.14.0",
+    "lodash": "^4.17.20",
     "mz": "^2.7.0",
-    "table": "^5.4.6",
-    "yargs": "^15.1.0"
+    "table": "^6.0.3",
+    "yargs": "^16.0.0"
   },
   "devDependencies": {
-    "@types/js-yaml": "^3.12.1",
-    "@types/lodash": "^4.14.149",
-    "@types/node": "^13.1.4",
-    "@types/table": "^4.0.7",
-    "@types/yargs": "^13.0.4",
-    "prettier": "^1.19.1",
-    "typescript": "^3.7.4"
+    "@types/humanize-duration": "^3.18.1",
+    "@types/js-yaml": "^3.12.5",
+    "@types/lodash": "^4.14.161",
+    "@types/mz": "^2.7.1",
+    "@types/node": "^14.6.4",
+    "@types/table": "^5.0.0",
+    "@types/yargs": "^15.0.5",
+    "@types/yargs-parser": "^15.0.0",
+    "prettier": "^2.1.1",
+    "typescript": "^4.0.2"
   },
   "homepage": "https://github.com/QDivision/chip",
   "repository": "git+https://github.com/QDivision/chip.git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ yargs
         alias: ['remove', 'rm'],
         type: 'boolean',
         describe:
-          'Whether or not to remove the containers after stopping them. Only applies to docker-compose services. If you have a database service and want wipe it clean, you could use this option.',
+          'Remove containers after stopping them. Only applies to docker-compose services. If you have a database service and want to clear/reset it, you could use this option.',
       }),
     handleErrors(async ({ services, remove = false }) => {
       await initChip();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,13 +77,18 @@ yargs
       await stopServices(services, remove);
     }),
   )
-  .command<{ services: string[] }>(
+  .command<{ services: string[]; remove: boolean }>(
     'restart [services..]',
     'Stop and restart services in project',
-    (yargs) => yargs.positional('services', { describe: 'service names' }),
-    handleErrors(async ({ services }) => {
+    (yargs) => yargs.positional('services', { describe: 'service names' }).option('r', {
+      alias: ['remove', 'rm'],
+      type: 'boolean',
+      describe:
+        'Remove containers after stopping them. Only applies to docker-compose services. If you have a database service and want to clear/reset it, you could use this option.',
+    }),
+    handleErrors(async ({ services, remove = false }) => {
       await initChip();
-      await restartServices(services);
+      await restartServices(services, remove);
     }),
   )
   .command<{ services: string[] }>(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,13 +62,19 @@ yargs
       await startServices(services);
     }),
   )
-  .command<{ services: string[] }>(
+  .command<{ services: string[]; remove: boolean }>(
     'stop [services..]',
     'Stop services in project',
-    (yargs) => yargs.positional('services', { describe: 'service names' }),
-    handleErrors(async ({ services }) => {
+    (yargs) =>
+      yargs.positional('services', { describe: 'service names' }).option('r', {
+        alias: ['remove', 'rm'],
+        type: 'boolean',
+        describe:
+          'Whether or not to remove the containers after stopping them. Only applies to docker-compose services. If you have a database service and want wipe it clean, you could use this option.',
+      }),
+    handleErrors(async ({ services, remove = false }) => {
       await initChip();
-      await stopServices(services);
+      await stopServices(services, remove);
     }),
   )
   .command<{ services: string[] }>(

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -1,5 +1,6 @@
 import { bold, green, red } from 'chalk';
 import { table } from 'table';
+import humanize from 'humanize-duration';
 
 import * as git from '../utils/git';
 import * as docker from '../utils/docker';
@@ -35,14 +36,32 @@ export const listServices = async () => {
   ];
 
   for (const { name, run = '' } of services) {
-    const pid = (activeProcesses[name] || {}).pid;
+    const { pid, startTime } = activeProcesses[name] || {};
     const exists = !!pid;
+
+    let status = '';
+    if (run) {
+      if (exists) {
+        if (startTime) {
+          const uptime = Date.now() - startTime!;
+          status = green(
+            `Up ${humanize(uptime, { largest: 1, maxDecimalPoints: 0 })}`,
+          );
+        } else {
+          // Handle cases where `startTime === undefined` for backwards
+          // compatibility
+          status = green(`Up`);
+        }
+      } else {
+        status = red('Stopped');
+      }
+    }
 
     // prettier-ignore
     tableData.push([
       name,
       run.substring(0, 20) + (run.length > 20 ? '...' : ''),
-      !run ? '' : (exists ? green('Running') : red('Stopped')),
+      status,
       exists ? String(pid) : '',
       await git.activeBranch(name),
     ]);

--- a/src/subcommands/list.ts
+++ b/src/subcommands/list.ts
@@ -44,9 +44,11 @@ export const listServices = async () => {
       if (exists) {
         if (startTime) {
           const uptime = Date.now() - startTime!;
-          status = green(
-            `Up ${humanize(uptime, { largest: 1, maxDecimalPoints: 0 })}`,
-          );
+          const prettyUptime = humanize(uptime, {
+            largest: 1,
+            maxDecimalPoints: 0,
+          });
+          status = green(`Up ${prettyUptime}`);
         } else {
           // Handle cases where `startTime === undefined` for backwards
           // compatibility

--- a/src/subcommands/restart.ts
+++ b/src/subcommands/restart.ts
@@ -10,10 +10,14 @@ import { startService } from './start';
 export const restartServices = async (serviceWhitelist: string[]) => {
   if (docker.isPresent()) {
     if (serviceWhitelist.length === 0) {
-      await docker.restart();
+      await docker.stop();
+      await docker.up();
     } else {
       const dockerServices = await docker.composeServiceNames(serviceWhitelist);
-      if (dockerServices.length > 0) await docker.restart(dockerServices);
+      if (dockerServices.length > 0) {
+        await docker.stop(dockerServices);
+        await docker.up(dockerServices);
+      }
     }
   }
 

--- a/src/subcommands/restart.ts
+++ b/src/subcommands/restart.ts
@@ -7,15 +7,20 @@ import { printError } from '../utils/errors';
 import { stopProcess } from './stop';
 import { startService } from './start';
 
-export const restartServices = async (serviceWhitelist: string[]) => {
+export const restartServices = async (
+  serviceWhitelist: string[],
+  removeDockerContainers = false,
+) => {
   if (docker.isPresent()) {
     if (serviceWhitelist.length === 0) {
-      await docker.stop();
+      if (removeDockerContainers) await docker.rm();
+      else docker.stop()
       await docker.up();
     } else {
       const dockerServices = await docker.composeServiceNames(serviceWhitelist);
       if (dockerServices.length > 0) {
-        await docker.stop(dockerServices);
+        if (removeDockerContainers) await docker.rm(dockerServices);
+        else await docker.stop(dockerServices);
         await docker.up(dockerServices);
       }
     }

--- a/src/subcommands/restart.ts
+++ b/src/subcommands/restart.ts
@@ -1,3 +1,4 @@
+import * as docker from '../utils/docker';
 import { readServices } from '../utils/config';
 import { PROJECT_NAME } from '../utils/files';
 import { log } from '../utils/log';
@@ -6,7 +7,16 @@ import { printError } from '../utils/errors';
 import { stopProcess } from './stop';
 import { startService } from './start';
 
-export const restartServices = async (serviceWhitelist?: string[]) => {
+export const restartServices = async (serviceWhitelist: string[]) => {
+  if (docker.isPresent()) {
+    if (serviceWhitelist.length === 0) {
+      await docker.restart();
+    } else {
+      const dockerServices = await docker.composeServiceNames(serviceWhitelist);
+      if (dockerServices.length > 0) await docker.restart(dockerServices);
+    }
+  }
+
   const services = await readServices(serviceWhitelist);
   const activeProcesses = await getActiveProcesses(PROJECT_NAME);
 

--- a/src/subcommands/start.ts
+++ b/src/subcommands/start.ts
@@ -1,4 +1,6 @@
 import fs from 'mz/fs';
+
+import * as docker from '../utils/docker';
 import { readServices, readScripts } from '../utils/config';
 import { PROJECT_NAME, CHIP_LOGS_DIR } from '../utils/files';
 import { log } from '../utils/log';
@@ -39,8 +41,14 @@ export const startService = async (
 };
 
 export const startServices = async (serviceWhitelist?: string[]) => {
-  if (await fs.exists(`./docker-compose.yml`)) {
-    await exec(`docker-compose up -d`, { cwd: '.', live: true });
+  // if (await fs.exists(`./docker-compose.yml`)) {
+  // await exec(`docker-compose up -d`, { cwd: '.', live: true });
+  // }
+
+  if (docker.isPresent()) {
+    // TODO: Filter `serviceWhitelist` for docker services
+    // If no whitelist is passed, all docker services will be started
+    await docker.up();
   }
 
   const services = await readServices(serviceWhitelist);

--- a/src/subcommands/stop.ts
+++ b/src/subcommands/stop.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import fs from 'mz/fs';
 
+import * as docker from '../utils/docker';
 import { exec } from '../utils/processes';
 import { processExists, getActiveProcesses } from '../utils/ps';
 import { PROJECT_NAME } from '../utils/files';
@@ -35,12 +36,18 @@ export const stopServices = async (serviceWhitelist: string[] = []) => {
   }
 
   try {
-    if (
-      serviceWhitelist.length === 0 &&
-      (await fs.exists(`./docker-compose.yml`))
-    ) {
-      await exec(`docker-compose stop`, { cwd: '.', live: true });
+    if (docker.isPresent()) {
+      // TODO: Filter `serviceWhitelist` for docker services
+      // If no whitelist is passed, all docker services will be stopped
+      // Also support `chip stop --remove` cli flag to call `docker.rm()`
+      await docker.stop();
     }
+    // if (
+    //   serviceWhitelist.length === 0 &&
+    //   (await fs.exists(`./docker-compose.yml`))
+    // ) {
+    //   await exec(`docker-compose stop`, { cwd: '.', live: true });
+    // }
   } catch (e) {
     printError(e);
   }

--- a/src/subcommands/stop.ts
+++ b/src/subcommands/stop.ts
@@ -19,7 +19,10 @@ export const stopProcess = async (name: string, pid: number) => {
   }
 };
 
-export const stopServices = async (serviceWhitelist: string[]) => {
+export const stopServices = async (
+  serviceWhitelist: string[],
+  removeDockerContainers = false,
+) => {
   const processes = await getActiveProcesses(PROJECT_NAME);
 
   const filteredProcesses = Object.entries(processes).filter(
@@ -37,10 +40,14 @@ export const stopServices = async (serviceWhitelist: string[]) => {
 
   if (docker.isPresent()) {
     if (serviceWhitelist.length === 0) {
-      await docker.stop();
+      if (removeDockerContainers) await docker.rm();
+      else await docker.stop();
     } else {
       const dockerServices = await docker.composeServiceNames(serviceWhitelist);
-      if (dockerServices.length > 0) await docker.stop(dockerServices);
+      if (dockerServices.length > 0) {
+        if (removeDockerContainers) await docker.rm(dockerServices);
+        else await docker.stop(dockerServices);
+      }
     }
   }
 };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,15 +26,15 @@ export interface ChipSecrets {
 
 export const readConfig = async (): Promise<ChipConfig> => {
   const chipYml = await fs.readFile('./chip.yml', 'utf8');
-  const chipConfig = await yaml.safeLoad(chipYml);
-  return chipConfig;
+  const chipConfig = (await yaml.safeLoad(chipYml) as any)
+  return chipConfig
 };
 
 export const readSecrets = async (): Promise<ChipSecrets> => {
   try {
     const secretYml = await fs.readFile('./secretchip.yml', 'utf8');
-    const secretConfig = await yaml.safeLoad(secretYml);
-    return secretConfig;
+    const secretConfig = (await yaml.safeLoad(secretYml) as any)
+    return secretConfig 
   } catch (e) {
     if (e.code === 'ENOENT') return {};
     else throw e;

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -25,21 +25,31 @@ export const isPresent = () => fs.existsSync(`${CWD}/docker-compose.yml`);
  * Start specified docker-compose services in this project.
  * If no services are specified, all of them will be started.
  */
-export const up = (services: string[] = []) =>
+export const up = async (services: string[] = []) =>
   exec(`docker-compose up -d ${services.join(' ')}`, { cwd: CWD, live: true });
 
 /**
  * Stop specified docker-compose services in this project.
  * If no services are specified, all of them will be stopped.
  */
-export const stop = (services: string[] = []) =>
+export const stop = async (services: string[] = []) =>
   exec(`docker-compose stop ${services.join(' ')}`, { cwd: CWD, live: true });
+
+/**
+ * Restart specified docker-compose services in this project.
+ * If no services are specified, all of them will be restarted.
+ */
+export const restart = async (services: string[] = []) =>
+  exec(`docker-compose restart ${services.join(' ')}`, {
+    cwd: CWD,
+    live: true,
+  });
 
 /**
  * Remove containers for specified docker-compose services in this project.
  * If no services are specified, all of them will be removed.
  */
-export const rm = (services: string[] = []) =>
+export const rm = async (services: string[] = []) =>
   exec(`docker-compose rm --stop --force ${services.join(' ')}`, {
     cwd: CWD,
     live: true,
@@ -51,6 +61,13 @@ export const composeServices = async (): Promise<{
   const composeYml = await fs.readFile(`${CWD}/docker-compose.yml`, 'utf8');
   const composeConfig = await yaml.safeLoad(composeYml);
   return composeConfig?.services ?? {};
+};
+
+/** Get names of docker-compose services in this project. */
+export const composeServiceNames = async (serviceWhitelist?: string[]) => {
+  const allServices = Object.keys(await composeServices());
+  if (!serviceWhitelist) return allServices;
+  return allServices.filter((n) => serviceWhitelist.includes(n));
 };
 
 /** Returns a list of all services in the `docker-compose.yml` file */

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -7,7 +7,7 @@ import { CWD } from '../utils/files';
 import { exec } from '../utils/processes';
 
 const capitalize = (value: string) =>
-  value.substring(0, 1).toUpperCase() + value.substring(1);
+  value.substring(0, 1).toUpperCase() + value.substring(1).toLowerCase();
 
 const run = (cmd: string) => exec(cmd, { cwd: '.', live: false });
 
@@ -20,6 +20,30 @@ const parseTable = (rawTable: string, skipRows = 0) =>
 
 /** Returns `true` if a `docker-compose.yml` file is present in the project */
 export const isPresent = () => fs.existsSync(`${CWD}/docker-compose.yml`);
+
+/**
+ * Start specified docker-compose services in this project.
+ * If no services are specified, all of them will be started.
+ */
+export const up = (services: string[] = []) =>
+  exec(`docker-compose up -d ${services.join(' ')}`, { cwd: CWD, live: true });
+
+/**
+ * Stop specified docker-compose services in this project.
+ * If no services are specified, all of them will be stopped.
+ */
+export const stop = (services: string[] = []) =>
+  exec(`docker-compose stop ${services.join(' ')}`, { cwd: CWD, live: true });
+
+/**
+ * Remove containers for specified docker-compose services in this project.
+ * If no services are specified, all of them will be removed.
+ */
+export const rm = (services: string[] = []) =>
+  exec(`docker-compose rm --stop --force ${services.join(' ')}`, {
+    cwd: CWD,
+    live: true,
+  });
 
 export const composeServices = async (): Promise<{
   [serviceName: string]: { image: string };

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -6,6 +6,9 @@ import { green, red } from 'chalk';
 import { CWD } from '../utils/files';
 import { exec } from '../utils/processes';
 
+const capitalize = (value: string) =>
+  value.substring(0, 1).toUpperCase() + value.substring(1);
+
 const run = (cmd: string) => exec(cmd, { cwd: '.', live: false });
 
 const parseTable = (rawTable: string, skipRows = 0) =>
@@ -47,7 +50,7 @@ export const listServices = async () => {
     return {
       name: serviceName,
       image,
-      status: info?.status ? green(info.status) : red('Stopped'),
+      status: info?.status ? green(capitalize(info.status)) : red('Stopped'),
     };
   });
 };

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -59,7 +59,7 @@ export const composeServices = async (): Promise<{
   [serviceName: string]: { image: string };
 }> => {
   const composeYml = await fs.readFile(`${CWD}/docker-compose.yml`, 'utf8');
-  const composeConfig = await yaml.safeLoad(composeYml);
+  const composeConfig = (await yaml.safeLoad(composeYml)) as any;
   return composeConfig?.services ?? {};
 };
 

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -5,8 +5,10 @@ import {
   CHIP_PROCESSES_FILE,
   writeJsonFile,
   CHIP_LOGS_DIR,
+  CWD,
 } from './files';
 import { readProcesses, ProcessRecord } from './config';
+import { printError } from './errors';
 
 export const initChip = async () => {
   if (!(await fs.exists(CHIP_DIR))) await fs.mkdir(CHIP_DIR);
@@ -14,6 +16,11 @@ export const initChip = async () => {
 
   if (!(await fs.exists(CHIP_PROCESSES_FILE))) {
     writeJsonFile(CHIP_PROCESSES_FILE, {});
+  }
+
+  if (!(await fs.exists('./chip.yml'))) {
+    printError({ message: `No chip.yml file found in ${CWD}` });
+    process.exit(1);
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,20 +12,20 @@
   resolved "https://registry.yarnpkg.com/@types/humanize-duration/-/humanize-duration-3.18.1.tgz#10090d596053703e7de0ac43a37b96cd9fc78309"
   integrity sha512-MUgbY3CF7hg/a/jogixmAufLjJBQT7WEf8Q+kYJkOc47ytngg1IuZobCngdTjAgY83JWEogippge5O5fplaQlw==
 
-"@types/js-yaml@^3.12.1":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.1.tgz#5c6f4a1eabca84792fbd916f0cb40847f123c656"
-  integrity sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==
+"@types/js-yaml@^3.12.5":
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
+  integrity sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==
 
-"@types/lodash@^4.14.149":
-  version "4.14.149"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
-  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
 
-"@types/mz@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@types/mz/-/mz-2.7.0.tgz#3ef27f457c4c3e8b197ca2670ee41d6f4effddf2"
-  integrity sha512-Q5TZYMKnH0hdV5fNstmMWL2LLw5eRRtTd73KNtsZxoQ2gtCQyET5X79uERUEwGneuxPglg441I7OSY00+9CkSw==
+"@types/mz@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@types/mz/-/mz-2.7.1.tgz#1ac1d69b039c8b3cbe603972b5c12d3167a84f58"
+  integrity sha512-H86h7KmRDVs9UeSiQvtUeVhS+WYpJSYSsZrRvNYpGWGiytEqxwEtvgRnINESQtCgnojIH2wS2WgaMTJP0firBw==
   dependencies:
     "@types/node" "*"
 
@@ -34,54 +34,47 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.6.tgz#076028d0b0400be8105b89a0a55550c86684ffec"
   integrity sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==
 
-"@types/node@^13.1.4":
-  version "13.1.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.5.tgz#4d5efc52a1d3e45d13e5ec9f911cbc5b089ccaec"
-  integrity sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g==
+"@types/node@^14.6.4":
+  version "14.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
+  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
-"@types/table@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@types/table/-/table-4.0.7.tgz#c21100d37d4924abbbde85414170260d4d7b0316"
-  integrity sha512-HKtXvBxU8U8evZCSlUi9HbfT/SFW7nSGCoiBEheB06jAhXeW6JbGh8biEAqIFG5rZo9f8xeJVdIn455sddmIcw==
+"@types/table@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/table/-/table-5.0.0.tgz#67c3821138eb41d538c3d9286771c6cdeeac7172"
+  integrity sha512-fQLtGLZXor264zUPWI95WNDsZ3QV43/c0lJpR/h1hhLJumXRmHNsrvBfEzW2YMhb0EWCsn4U6h82IgwsajAuTA==
 
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
   integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
 
-"@types/yargs@^13.0.4":
-  version "13.0.5"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.5.tgz#18121bfd39dc12f280cee58f92c5b21d32041908"
-  integrity sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==
+"@types/yargs-parser@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs@^15.0.5":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
 
-ajv@^6.10.2:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
-  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+ajv@^6.12.4:
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
+  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
-    fast-deep-equal "^2.0.1"
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-styles@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
@@ -103,39 +96,27 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-camelcase@^5.0.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-cliui@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
-  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+cliui@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.1.tgz#a4cb67aad45cd83d8d05128fc9f4d8fbb887e6b3"
+  integrity sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
-    wrap-ansi "^6.2.0"
-
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
+    wrap-ansi "^7.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -144,55 +125,37 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-decamelize@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
-
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+escalade@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
+  integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -207,20 +170,15 @@ humanize-duration@^3.23.1:
   resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.23.1.tgz#59cb8d01287479c1aa7cd5b1efc260d799bef89b"
   integrity sha512-aoOEkomAETmVuQyBx4E7/LfPlC9s8pAA/USl7vFRQpDjepo3aiyvFfOhtXSDqPowdBVPFUZ7onG/KyuolX0qPg==
 
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -230,17 +188,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
-
-lodash@^4.17.14, lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 mz@^2.7.0:
   version "2.7.0"
@@ -256,34 +207,10 @@ object-assign@^4.0.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-p-limit@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
-  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
-  dependencies:
-    p-try "^2.0.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
-
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
+  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -295,38 +222,19 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
   dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
@@ -336,13 +244,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
@@ -358,15 +259,15 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-table@^5.4.6:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+table@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.0.3.tgz#e5b8a834e37e27ad06de2e0fda42b55cfd8a0123"
+  integrity sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==
   dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    ajv "^6.12.4"
+    lodash "^4.17.20"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
 
 thenify-all@^1.0.0:
   version "1.6.0"
@@ -382,10 +283,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-typescript@^3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -394,46 +295,34 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+y18n@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.1.tgz#1ad2a7eddfa8bce7caa2e1f6b5da96c39d99d571"
+  integrity sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==
 
-yargs-parser@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
-  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
+yargs-parser@^19.0.4:
+  version "19.0.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-19.0.4.tgz#99183a3a59268b205c6b04177f2a5bfb46e79ba7"
+  integrity sha512-eXeQm7yXRjPFFyf1voPkZgXQZJjYfjgQUmGPbD2TLtZeIYzvacgWX7sQ5a1HsRgVP+pfKAkRZDNtTGev4h9vhw==
 
-yargs@^15.1.0:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
-  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+yargs@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.0.0.tgz#767d0e914605c0fc4e4ffd3bf214d8e56182da19"
+  integrity sha512-Ykb00VnWjee855QmeCrDAAmhVagt0T8PMML9WS2YrcU0VtvbeGq02MD7UiWmK6biiVPas6CaXmJNetL4Ye4+ng==
   dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
+    cliui "^7.0.0"
+    escalade "^3.0.2"
+    get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
     string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^16.1.0"
+    y18n "^5.0.1"
+    yargs-parser "^19.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/humanize-duration@^3.18.1":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@types/humanize-duration/-/humanize-duration-3.18.1.tgz#10090d596053703e7de0ac43a37b96cd9fc78309"
+  integrity sha512-MUgbY3CF7hg/a/jogixmAufLjJBQT7WEf8Q+kYJkOc47ytngg1IuZobCngdTjAgY83JWEogippge5O5fplaQlw==
+
 "@types/js-yaml@^3.12.1":
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.1.tgz#5c6f4a1eabca84792fbd916f0cb40847f123c656"
@@ -196,6 +201,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+humanize-duration@^3.23.1:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.23.1.tgz#59cb8d01287479c1aa7cd5b1efc260d799bef89b"
+  integrity sha512-aoOEkomAETmVuQyBx4E7/LfPlC9s8pAA/USl7vFRQpDjepo3aiyvFfOhtXSDqPowdBVPFUZ7onG/KyuolX0qPg==
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR focuses on improving chip's integration with `docker` and `docker-compose`. Specific changes are as follows:
* Show process uptime in `chip list` output.
* Add `-r` (`--rm`, `--remove`) flag to `chip stop` to allow docker container images to be removed when stopped. This emulates the behavior of `docker-compose down` and is useful for clearing database images, among other things.
* Allow docker services to be restarted with `chip restart` (also supports the `-r` flag to remove containers).
* Allow individual docker services to be passed to `chip start`, `chip stop`, and `chip restart`. 
* Improve error message when `chip.yml` file is missing from the current directory.
* Update dependencies.

For example, to restart a process and its database (while wiping the DB's data and leaving other processes and docker services untouched):
```
$ chip restart -r super-duper-service super-duper-db
```
(where `super-duper-service` is defined in the `chip.yml` and `super-duper-db` is defined in the `docker-compose.yml`)