### PR TITLE
Fix restart bug & improve DX

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
 
-import { initChip } from './utils/ps';
+import { initChip, assertSubdirs } from './utils/init';
 import { handleErrors } from './utils/errors';
 
 import { syncServices } from './subcommands/sync';
@@ -12,6 +12,7 @@ import { listServices } from './subcommands/list';
 import { logServices } from './subcommands/logs';
 import { checkoutServices } from './subcommands/checkout';
 import { statusServices } from './subcommands/status';
+import { cleanNames } from './utils/strings';
 
 yargs
   .command<{ services: string[] }>(
@@ -20,7 +21,7 @@ yargs
     (yargs) => yargs.positional('services', { describe: 'service names' }),
     handleErrors(async ({ services }) => {
       await initChip();
-      await syncServices(services);
+      await syncServices(cleanNames(services));
     }),
   )
   .command<{ branch: string; services: string[] }>(
@@ -32,7 +33,8 @@ yargs
         .positional('services', { describe: 'service names' }),
     handleErrors(async ({ branch, services }) => {
       await initChip();
-      await checkoutServices(branch, services);
+      await assertSubdirs();
+      await checkoutServices(branch, cleanNames(services));
     }),
   )
   .command<{ services: string[] }>(
@@ -41,7 +43,8 @@ yargs
     (yargs) => yargs.positional('services', { describe: 'service names' }),
     handleErrors(async ({ services }) => {
       await initChip();
-      await statusServices(services);
+      await assertSubdirs();
+      await statusServices(cleanNames(services));
     }),
   )
   .command<{ services: string[] }>(
@@ -50,7 +53,8 @@ yargs
     (yargs) => yargs.positional('services', { describe: 'service names' }),
     handleErrors(async ({ services }) => {
       await initChip();
-      await installServices(services);
+      await assertSubdirs();
+      await installServices(cleanNames(services));
     }),
   )
   .command<{ services: string[] }>(
@@ -59,7 +63,8 @@ yargs
     (yargs) => yargs.positional('services', { describe: 'service names' }),
     handleErrors(async ({ services }) => {
       await initChip();
-      await startServices(services);
+      await assertSubdirs();
+      await startServices(cleanNames(services));
     }),
   )
   .command<{ services: string[]; remove: boolean }>(
@@ -74,21 +79,24 @@ yargs
       }),
     handleErrors(async ({ services, remove = false }) => {
       await initChip();
-      await stopServices(services, remove);
+      await assertSubdirs();
+      await stopServices(cleanNames(services), remove);
     }),
   )
   .command<{ services: string[]; remove: boolean }>(
     'restart [services..]',
     'Stop and restart services in project',
-    (yargs) => yargs.positional('services', { describe: 'service names' }).option('r', {
-      alias: ['remove', 'rm'],
-      type: 'boolean',
-      describe:
-        'Remove containers after stopping them. Only applies to docker-compose services. If you have a database service and want to clear/reset it, you could use this option.',
-    }),
+    (yargs) =>
+      yargs.positional('services', { describe: 'service names' }).option('r', {
+        alias: ['remove', 'rm'],
+        type: 'boolean',
+        describe:
+          'Remove containers after stopping them. Only applies to docker-compose services. If you have a database service and want to clear/reset it, you could use this option.',
+      }),
     handleErrors(async ({ services, remove = false }) => {
       await initChip();
-      await restartServices(services, remove);
+      await assertSubdirs();
+      await restartServices(cleanNames(services), remove);
     }),
   )
   .command<{ services: string[] }>(
@@ -97,7 +105,8 @@ yargs
     (yargs) => yargs.positional('services', { describe: 'service names' }),
     handleErrors(async ({ services }) => {
       await initChip();
-      await logServices(services);
+      await assertSubdirs();
+      await logServices(cleanNames(services));
     }),
   )
   .command(
@@ -106,6 +115,7 @@ yargs
     {},
     handleErrors(async () => {
       await initChip();
+      await assertSubdirs();
       await listServices();
     }),
   )

--- a/src/subcommands/install.ts
+++ b/src/subcommands/install.ts
@@ -1,3 +1,5 @@
+import { last } from 'lodash';
+
 import { readServices, readScripts } from '../utils/config';
 import { exec } from '../utils/processes';
 import { log } from '../utils/log';
@@ -43,5 +45,6 @@ export const installServices = async (serviceWhitelist?: string[]) => {
     } catch (e) {
       printError(e);
     }
+    if (name !== last(services)?.name) console.log();
   }
 };

--- a/src/subcommands/restart.ts
+++ b/src/subcommands/restart.ts
@@ -14,7 +14,7 @@ export const restartServices = async (
   if (docker.isPresent()) {
     if (serviceWhitelist.length === 0) {
       if (removeDockerContainers) await docker.rm();
-      else docker.stop()
+      else await docker.stop();
       await docker.up();
     } else {
       const dockerServices = await docker.composeServiceNames(serviceWhitelist);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,15 +26,15 @@ export interface ChipSecrets {
 
 export const readConfig = async (): Promise<ChipConfig> => {
   const chipYml = await fs.readFile('./chip.yml', 'utf8');
-  const chipConfig = (await yaml.safeLoad(chipYml) as any)
-  return chipConfig
+  const chipConfig = (await yaml.safeLoad(chipYml)) as any;
+  return chipConfig;
 };
 
 export const readSecrets = async (): Promise<ChipSecrets> => {
   try {
     const secretYml = await fs.readFile('./secretchip.yml', 'utf8');
-    const secretConfig = (await yaml.safeLoad(secretYml) as any)
-    return secretConfig 
+    const secretConfig = (await yaml.safeLoad(secretYml)) as any;
+    return secretConfig;
   } catch (e) {
     if (e.code === 'ENOENT') return {};
     else throw e;
@@ -52,14 +52,16 @@ export const readScripts = async () => {
 
 export const readServices = async (
   whitelist: string[] = [],
-): Promise<{
-  name: string;
-  repo?: string;
-  install?: string;
-  run?: string;
-  env: { [envVar: string]: string };
-  secrets: { [name: string]: string };
-}[]> => {
+): Promise<
+  {
+    name: string;
+    repo?: string;
+    install?: string;
+    run?: string;
+    env: { [envVar: string]: string };
+    secrets: { [name: string]: string };
+  }[]
+> => {
   const config = await readConfig();
   const secrets = await readSecrets();
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -2,6 +2,7 @@ import { exec } from './processes';
 
 export const activeBranch = async (cwd: string) => {
   const output = await exec('git branch', { cwd });
+  if (output.trim() === '') return '';
   const targetLine = output.split('\n').find((line) => line.includes('*'));
   if (!targetLine) throw new Error('Failed to parse `git branch` output');
   return targetLine.substring(2);

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,0 +1,35 @@
+import fs from 'mz/fs';
+import {
+  CHIP_DIR,
+  CHIP_PROCESSES_FILE,
+  writeJsonFile,
+  CHIP_LOGS_DIR,
+  CWD,
+} from './files';
+import { printError } from './errors';
+import { readServices } from './config';
+
+export const initChip = async () => {
+  if (!(await fs.exists(CHIP_DIR))) await fs.mkdir(CHIP_DIR);
+  if (!(await fs.exists(CHIP_LOGS_DIR))) await fs.mkdir(CHIP_LOGS_DIR);
+
+  if (!(await fs.exists(CHIP_PROCESSES_FILE))) {
+    writeJsonFile(CHIP_PROCESSES_FILE, {});
+  }
+
+  if (!(await fs.exists('./chip.yml'))) {
+    printError({ message: `No chip.yml file found in ${CWD}` });
+    process.exit(1);
+  }
+};
+
+export const assertSubdirs = async () => {
+  const services = await readServices();
+  for (const { name } of services) {
+    if (!(await fs.exists(name))) {
+      const message = `${name} is defined in chip.yml but no ./${name} directory exists. Have you run \`chip sync\`?`;
+      printError({ message });
+      process.exit(1);
+    }
+  }
+};

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -1,28 +1,7 @@
 import fs from 'mz/fs';
 import { exec } from './processes';
-import {
-  CHIP_DIR,
-  CHIP_PROCESSES_FILE,
-  writeJsonFile,
-  CHIP_LOGS_DIR,
-  CWD,
-} from './files';
+import { CHIP_PROCESSES_FILE, writeJsonFile, CHIP_LOGS_DIR } from './files';
 import { readProcesses, ProcessRecord } from './config';
-import { printError } from './errors';
-
-export const initChip = async () => {
-  if (!(await fs.exists(CHIP_DIR))) await fs.mkdir(CHIP_DIR);
-  if (!(await fs.exists(CHIP_LOGS_DIR))) await fs.mkdir(CHIP_LOGS_DIR);
-
-  if (!(await fs.exists(CHIP_PROCESSES_FILE))) {
-    writeJsonFile(CHIP_PROCESSES_FILE, {});
-  }
-
-  if (!(await fs.exists('./chip.yml'))) {
-    printError({ message: `No chip.yml file found in ${CWD}` });
-    process.exit(1);
-  }
-};
 
 export const processExists = async (pid: number) => {
   try {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,11 @@
+const hasTrailingSlash = (name: string) => name[name.length - 1] === '/';
+
+const removeTrailingSlash = (name: string) =>
+  hasTrailingSlash(name) ? name.substring(0, name.length - 1) : name;
+
+/** Remove trailing slashes from services names */
+export const cleanNames = (serviceNames: string[]) =>
+  serviceNames.map((name) => {
+    while (hasTrailingSlash(name)) name = removeTrailingSlash(name);
+    return name;
+  });


### PR DESCRIPTION
* Allow trailing slashes in input service names, e.g.
  ```
  chip restart sandwich-ui/ sandwich-api/
  ```
* Improve error message when services are missing, e.g.
  ```
  Error: sandwich-ui is defined in chip.yml but no ./sandwich-ui directory exists. Have you run `chip sync`?
  ```
* Fix bug that occasionally prevented services from starting back up when `chip restart` is run.
* Formatting fixes.