### PR TITLE
Adjust the logging logic to be more consistent/Fix missing ability to stop by tag

### DIFF
--- a/src/subcommands/logs.ts
+++ b/src/subcommands/logs.ts
@@ -15,15 +15,17 @@ export const logService = async (
   color: chalk.Chalk,
   offset: number,
 ) => {
-  const fileName = `${CHIP_LOGS_DIR}/${projectName}/${serviceName}.log`;
+  const fileName = `${CHIP_LOGS_DIR}/${projectName}/${serviceName}.log.timestamps`;
   const subprocess = spawn('tail', ['-f', '-c', `+${offset}`, fileName]);
   [subprocess.stdout, subprocess.stderr].forEach((stream) => {
     const rl = readline.createInterface({ input: stream });
 
     rl.on('line', (line) => {
+      const firstSpace = line.indexOf(' ');
+      const log = line.substring(firstSpace + 1);
       const paddedName = serviceName.padEnd(padLength);
       const prefix = color(chalk.bold(`${paddedName} | `));
-      console.log(prefix + line);
+      console.log(prefix + log);
     });
 
     stream.on('exit', (data) => {


### PR DESCRIPTION
I've noticed how sometimes `chip logs` will not tail correctly, and instead the ending "BUILD SUCCESS" maven output is the only thing that displays. Additionally, on restarts, newer logs for the same service would appear above the logs for the process that was being shut down, leading to confusion.

With this change in my local, `chip logs` always tails the necessary log files appropriately and in the expected order.

Happy to get feedback if I'm breaking something here, but it was hard to use the logging feature in its current state...