### PR TITLE
Add types to errors

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -36,7 +36,7 @@ export const readSecrets = async (): Promise<ChipSecrets> => {
     const secretYml = await fs.readFile('./secretchip.yml', 'utf8');
     const secretConfig = (await yaml.safeLoad(secretYml)) as any;
     return secretConfig;
-  } catch (e) {
+  } catch (e: NodeJS.ErrnoException) {
     if (e.code === 'ENOENT') return {};
     else throw e;
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -36,7 +36,7 @@ export const readSecrets = async (): Promise<ChipSecrets> => {
     const secretYml = await fs.readFile('./secretchip.yml', 'utf8');
     const secretConfig = (await yaml.safeLoad(secretYml)) as any;
     return secretConfig;
-  } catch (e: NodeJS.ErrnoException) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') return {};
     else throw e;
   }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -14,7 +14,7 @@ export const fileExists = async (path: string) => {
   try {
     await fs.stat(path);
     return true;
-  } catch (e) {
+  } catch (e: NodeJS.ErrnoException) {
     if (e.code === 'ENOENT') return false;
     throw e;
   }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -14,7 +14,7 @@ export const fileExists = async (path: string) => {
   try {
     await fs.stat(path);
     return true;
-  } catch (e: NodeJS.ErrnoException) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') return false;
     throw e;
   }

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -21,7 +21,7 @@ export const lookupStartTime = async (pid: number) => {
     // Sample output: `Wed Sep  2 11:17:24 2020`
     const startDate = await exec(`ps -p ${pid} -o lstart=`);
     return new Date(startDate).getTime();
-  } catch (e) {
+  } catch (e: Error) {
     if (e.message) {
       e.message = `Failed to get start start time for pid ${pid}: ${e.message}`;
     }

--- a/src/utils/ps.ts
+++ b/src/utils/ps.ts
@@ -21,7 +21,7 @@ export const lookupStartTime = async (pid: number) => {
     // Sample output: `Wed Sep  2 11:17:24 2020`
     const startDate = await exec(`ps -p ${pid} -o lstart=`);
     return new Date(startDate).getTime();
-  } catch (e: Error) {
+  } catch (e: any) {
     if (e.message) {
       e.message = `Failed to get start start time for pid ${pid}: ${e.message}`;
     }


### PR DESCRIPTION
Fixes `'e' is of type 'unknown'` errors when building chip with [dream2nix](https://github.com/nix-community/dream2nix)